### PR TITLE
Changed gopus import

### DIFF
--- a/dgvoice.go
+++ b/dgvoice.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 
 	"github.com/bwmarrin/discordgo"
-	"github.com/layeh/gopus"
+	"layeh.com/gopus"
 )
 
 // NOTE: This API is not final and these are likely to change.


### PR DESCRIPTION
For some reason layeh changed import path in gopus, so it is necessary to use his own domain (which redirects back to github) rather than the GitHub import path.

I personally don't agree with this, because it's less reliable, but it is necessary for dgvoice to work.