### PR TITLE
Fix the problem of overlapping audio stream on multiple voice channels

### DIFF
--- a/dgvoice.go
+++ b/dgvoice.go
@@ -44,9 +44,9 @@ var OnError = func(str string, err error) {
 	prefix := "dgVoice: " + str
 
 	if err != nil {
-		os.Stderr.WriteString(prefix + ": " + err.Error())
+		os.Stderr.WriteString(prefix + ": " + err.Error() + "\n")
 	} else {
-		os.Stderr.WriteString(prefix)
+		os.Stderr.WriteString(prefix + "\n")
 	}
 }
 
@@ -74,7 +74,7 @@ func SendPCM(v *discordgo.VoiceConnection, pcm <-chan []int16) {
 		// read pcm from chan, exit if channel is closed.
 		recv, ok := <-pcm
 		if !ok {
-			OnError("PCM Channel closed", nil)
+			//OnError("PCM Channel closed", nil) //annoying log output
 			return
 		}
 

--- a/dgvoice.go
+++ b/dgvoice.go
@@ -16,7 +16,6 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
-	"sync"
 
 	"github.com/bwmarrin/discordgo"
 	"layeh.com/gopus"
@@ -35,9 +34,8 @@ const (
 )
 
 var (
-	speakers    map[uint32]*gopus.Decoder
-	opusEncoder *gopus.Encoder
-	mu          sync.Mutex
+	speakers map[uint32]*gopus.Decoder
+	//mu          sync.Mutex            // commented because it's not using currently
 )
 
 // OnError gets called by dgvoice when an error is encountered.
@@ -61,7 +59,10 @@ func SendPCM(v *discordgo.VoiceConnection, pcm <-chan []int16) {
 
 	var err error
 
-	opusEncoder, err = gopus.NewEncoder(frameRate, channels, gopus.Audio)
+	// opusEncoder must be the local variable
+	// so that a bot can stream different files on different channel on each multiple guild
+	// otherwise multiple audio stream overlaps and stutters, not listening clearly.
+	opusEncoder, err := gopus.NewEncoder(frameRate, channels, gopus.Audio)
 
 	if err != nil {
 		OnError("NewEncoder Error", err)


### PR DESCRIPTION
- What I wanted:
  - Single bot (1 process)
  - Guild 0's voice channel ← play file 0
  - Guild 1's voice channel ← play file 1

- Implementation:
```go
// for guild 0
go func() {
	voiceSession0, _ := discordgo.ChannelVoiceJoin(guildID0, channelID0, false, true)
	dgvoice.PlayAudioFile(voiceSession0, "audio0.ogg", make(<-chan bool))
}()
// for guild 1
go func() {
	voiceSession1, _ := discordgo.ChannelVoiceJoin(guildID1, channelID1, false, true)
	dgvoice.PlayAudioFile(voiceSession1, "audio1.ogg", make(<-chan bool))
}()
```

- Result:
  - `audio0.ogg` and `audio1.ogg` overlap each other
  - a bot sends stuttering audio stream on both voice channel (can't listen smoothly)

- How to fix:
  - make `opusEncoder` as a local variable in `SendPCM` function